### PR TITLE
Partially address #1: Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:latest
+ENV WDIR=/app
+WORKDIR ${WDIR}
+COPY . ${WDIR}
+# Install euchre package locally since not published to PyPI
+RUN ["pip3", "install", "."]
+EXPOSE 6000/tcp
+# Unsure how heartbeats work completely still, assuming needs exposed
+EXPOSE 5999/udp
+CMD ["euchre-server"]

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'click',
+        'numpy',
     ],
     python_requires='>=3.6',
     entry_points={


### PR DESCRIPTION
- Add Dockerfile
  - Can just `docker build . -t euchrepy:latest` now
  - `docker run -d euchrepy:latest` to run server
  - Exposes port 5999 and 6000
- Adjust `setup.py`
  - Needed `numpy`, usually installed in system `site-packages` but not in containers